### PR TITLE
Added setters for token and host

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,9 +66,28 @@ ActiveCollabJS.prototype.init = function(params, callback) {
  * @return {issueToken~response}      :: callback
  */
 ActiveCollabJS.prototype.__request = function(method, params, callback) {
-  let url = this.host + path.join('api/v1/', method);
+  const host = this.host.endsWith("/") ? this.host : `${this.host}/`
+  const url = host + path.join('api/v1/', method);
 
   request(url, params, (err, res, body) => callback(err, body));
+};
+
+
+/**
+ * Set host
+ * @param  {String}   host            :: the host to use in requests
+ */
+ActiveCollabJS.prototype.setHost = function(host) {
+  this.host = host;
+};
+
+
+/**
+ * Set previously obtained token
+ * @param  {String}   token           :: the token
+ */
+ActiveCollabJS.prototype.setToken = function(token) {
+  this.token = token;
 };
 
 


### PR DESCRIPTION
This PR adds `setToken()` and `setHost()`, to be used when you already have a logged-in user and can skip the `issue-token` API call.

Other than that, I did a tiny normalisation of the host before using it in the request.  
This makes sure a slash is present between host and path.

I'd be happy to receive your feedback!